### PR TITLE
Use onMount for root redirect to avoid SSR issues

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import { pb } from '$lib/pocketbase';
   import { goto } from '$app/navigation';
-  if (pb.authStore.isValid) {
-    goto('/dashboard');
-  } else {
-    goto('/login');
-  }
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    if (pb.authStore.isValid) {
+      goto('/dashboard');
+    } else {
+      goto('/login');
+    }
+  });
 </script>


### PR DESCRIPTION
## Summary
- Redirect to `/dashboard` or `/login` after mount instead of at module level

## Testing
- `npm test` *(fails: Cannot find module './.svelte-kit/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_689c3f54b48c8330b461878722716591