### PR TITLE
feat: add tenant package roles

### DIFF
--- a/collections/roles.json
+++ b/collections/roles.json
@@ -1,0 +1,4 @@
+[
+  { "name": "name", "type": "text", "required": true },
+  { "name": "owner", "type": "text", "required": true }
+]

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,13 +1,40 @@
-export enum Role {
-  MASTER = 'master',
-  WHITE_LABEL = 'whitelabel',
-  END_USER = 'user'
+import { pb } from './pocketbase';
+
+export const CORE_ROLES = {
+  MASTER: 'master',
+  WHITE_LABEL: 'whitelabel',
+  END_USER: 'user'
+} as const;
+
+export type Role = typeof CORE_ROLES[keyof typeof CORE_ROLES] | string;
+
+export const roleHierarchy: Role[] = [
+  CORE_ROLES.MASTER,
+  CORE_ROLES.WHITE_LABEL,
+  CORE_ROLES.END_USER
+];
+
+let customRoles: string[] = [];
+
+export function extendRoles(roles: string[]): void {
+  customRoles = roles;
 }
 
-export const roleHierarchy = [Role.MASTER, Role.WHITE_LABEL, Role.END_USER];
+export async function loadCustomRoles(ownerId: string): Promise<string[]> {
+  const records = await pb
+    .collection('roles')
+    .getFullList({ filter: `owner="${ownerId}"` });
+  const names = records.map((r: any) => r.name);
+  extendRoles(names);
+  return names;
+}
+
+function normalize(role: Role): Role {
+  return customRoles.includes(role) ? CORE_ROLES.END_USER : role;
+}
 
 export function hasRole(userRole: Role, required: Role): boolean {
-  return (
-    roleHierarchy.indexOf(userRole) <= roleHierarchy.indexOf(required)
-  );
+  const userIndex = roleHierarchy.indexOf(normalize(userRole));
+  const requiredIndex = roleHierarchy.indexOf(normalize(required));
+  return userIndex !== -1 && requiredIndex !== -1 && userIndex <= requiredIndex;
 }

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -2,7 +2,7 @@
   import { pb } from '$lib/pocketbase';
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
-  import { Role, hasRole } from '$lib/roles';
+  import { CORE_ROLES, hasRole } from '$lib/roles';
   let user = pb.authStore.model;
 
   onMount(() => {
@@ -25,10 +25,11 @@
   <button class="mt-4 bg-gray-500 text-white px-4 py-2 rounded" on:click={logout}>
     Logout
   </button>
-  {#if hasRole(user.role, Role.MASTER)}
+  {#if hasRole(user.role, CORE_ROLES.MASTER)}
     <p class="mt-4">Master admin panel</p>
-  {:else if hasRole(user.role, Role.WHITE_LABEL)}
+  {:else if hasRole(user.role, CORE_ROLES.WHITE_LABEL)}
     <p class="mt-4">White-label partner dashboard</p>
+    <a href="/dashboard/roles" class="block mt-2 underline text-blue-600">Manage package roles</a>
   {:else}
     <p class="mt-4">End-user dashboard</p>
   {/if}

--- a/src/routes/dashboard/roles/+page.svelte
+++ b/src/routes/dashboard/roles/+page.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { pb } from '$lib/pocketbase';
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { CORE_ROLES } from '$lib/roles';
+
+  let user = pb.authStore.model;
+  let roles: any[] = [];
+  let name = '';
+
+  onMount(async () => {
+    if (!pb.authStore.isValid) {
+      goto('/login');
+      return;
+    }
+    user = pb.authStore.model;
+    if (user.role !== CORE_ROLES.WHITE_LABEL) {
+      goto('/dashboard');
+      return;
+    }
+    await loadRoles();
+  });
+
+  async function loadRoles() {
+    roles = await pb.collection('roles').getFullList({ filter: `owner="${user.id}"` });
+  }
+
+  async function createRole() {
+    if (!name) return;
+    await pb.collection('roles').create({ name, owner: user.id });
+    name = '';
+    await loadRoles();
+  }
+</script>
+
+<h1 class="text-xl font-bold mb-4">Manage Package Roles</h1>
+<div class="flex space-x-2 mb-4">
+  <input class="border p-2 flex-1" placeholder="Role name" bind:value={name} />
+  <button class="bg-blue-500 text-white px-4 py-2 rounded" on:click={createRole}>Add</button>
+</div>
+<ul class="list-disc pl-5">
+  {#each roles as r}
+    <li>{r.name}</li>
+  {/each}
+</ul>

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -1,14 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import { hasRole, Role } from '../src/lib/roles';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { hasRole, CORE_ROLES, extendRoles } from '../src/lib/roles';
 
 describe('hasRole', () => {
+  beforeEach(() => extendRoles([]));
+
   it('allows masters access to all roles', () => {
-    expect(hasRole(Role.MASTER, Role.END_USER)).toBe(true);
-    expect(hasRole(Role.MASTER, Role.WHITE_LABEL)).toBe(true);
+    expect(hasRole(CORE_ROLES.MASTER, CORE_ROLES.END_USER)).toBe(true);
+    expect(hasRole(CORE_ROLES.MASTER, CORE_ROLES.WHITE_LABEL)).toBe(true);
   });
 
   it('restricts end users from higher roles', () => {
-    expect(hasRole(Role.END_USER, Role.MASTER)).toBe(false);
-    expect(hasRole(Role.END_USER, Role.WHITE_LABEL)).toBe(false);
+    expect(hasRole(CORE_ROLES.END_USER, CORE_ROLES.MASTER)).toBe(false);
+    expect(hasRole(CORE_ROLES.END_USER, CORE_ROLES.WHITE_LABEL)).toBe(false);
+  });
+
+  it('treats custom roles as end user level', () => {
+    extendRoles(['gold']);
+    expect(hasRole('gold', CORE_ROLES.END_USER)).toBe(true);
+    expect(hasRole('gold', CORE_ROLES.WHITE_LABEL)).toBe(false);
+    expect(hasRole(CORE_ROLES.WHITE_LABEL, 'gold')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add PocketBase collection for tenant package roles
- merge runtime package roles with core role hierarchy
- allow white-label users to manage custom roles in dashboard
- validate custom role permissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c614c86ec8330984c03e8d647388a